### PR TITLE
chore/codeowners self

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Junction-Engine
+* @Junction-Engine/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Junction-Engine/maintainers
+* @Junction-Engine

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,6 @@
 name: codeql
 on:
+  workflow_dispatch:
   push: { branches: [ main ] }
   pull_request: { branches: [ main ] }
   schedule: [ { cron: '0 8 * * 1' } ]


### PR DESCRIPTION
- **chore: CODEOWNERS → @Junction-Engine/maintainers**
- **ci: allow manual CodeQL runs (workflow_dispatch)**
- **chore: CODEOWNERS → me (until team exists)**
